### PR TITLE
Fix typo in 'receiver_email' parameter and variable name

### DIFF
--- a/utilities/email_service.py
+++ b/utilities/email_service.py
@@ -17,10 +17,10 @@ def generate_OTP(length=6):
     return otp
 
 
-def send_email(reciever_email, subject, body):
+def send_email(receiver_email, subject, body):
     msg = MIMEMultipart()
     msg['From'] = sender_email
-    msg['To'] = reciever_email
+    msg['To'] = receiver_email
     msg['Subject'] = subject
     msg.attach(MIMEText(body, 'plain'))
 


### PR DESCRIPTION
Corrected the spelling of 'receiver_email' in the `send_email` function to ensure consistency and clarity. This change has no functional impact but improves code readability and reduces potential confusion.